### PR TITLE
Add default header padding

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,7 @@
 import Logo from './Logo.astro';
 ---
 
-<header class="fixed w-full bg-white/95 backdrop-blur-sm shadow-sm z-50 transition-all duration-300">
+<header class="fixed w-full bg-white/95 backdrop-blur-sm shadow-sm z-50 transition-all duration-300 py-4">
   <div class="container-custom py-3">
     <div class="flex justify-between items-center">
       <a href="/" class="flex items-center">


### PR DESCRIPTION
## Summary
- add default `py-4` padding to the header

## Testing
- `npm run build` *(fails: astro not found)*