### PR TITLE
Update README with project intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
-# Astro Starter Kit: Basics
+# Dallas Door Pros
 
-```sh
-npm create astro@latest -- --template basics
-```
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
+Dallas Door Pros provides reliable garage door installation and repair services throughout the Dallas area. This repository contains the source for our website built with Astro and Tailwind CSS.
 
 ## 🚀 Project Structure
 


### PR DESCRIPTION
## Summary
- replace Astro starter kit intro with details about Dallas Door Pros
- remove template-specific instruction

## Testing
- `npm run build` *(fails: astro not found)*